### PR TITLE
Initial benchmarks implemented

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,8 @@ uuid = {version = "0.8.1", features = ["serde", "v4"]}
 
 [dev-dependencies]
 env_logger = "0.8.2"
+criterion = "0.3.3"
+
+[[bench]]
+name = "evt"
+harness = false

--- a/benches/evt.rs
+++ b/benches/evt.rs
@@ -1,0 +1,54 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use evt::message_store::{Get, MessageData, Put};
+use evt::{message_store, stream_name};
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("put 1", |b| {
+        let mut store = message_store::controls::message_store();
+        let stream = stream_name::controls::unique_example();
+        let data = message_store::controls::new_example();
+
+        b.iter(|| store.put(&data, &stream, None))
+    });
+
+    c.bench_function("put 100", |b| {
+        let mut store = message_store::controls::message_store();
+        let stream = stream_name::controls::unique_example();
+        let data: Vec<MessageData> = (0..100)
+            .map(|_| message_store::controls::new_example())
+            .collect();
+
+        b.iter(|| store.put_many(data.iter().collect(), &stream, None))
+    });
+
+    c.bench_function("get 1", |b| {
+        let mut store = message_store::controls::message_store();
+        store.settings.batch_size = Some(1);
+        let stream = stream_name::controls::unique_example();
+        let data = message_store::controls::new_example();
+        &store.put(&data, &stream, None).unwrap();
+
+        b.iter(|| store.get(&stream, None))
+    });
+
+    c.bench_function("get 100", |b| {
+        let mut store = message_store::controls::message_store();
+        store.settings.batch_size = Some(100);
+        let stream = stream_name::controls::unique_example();
+        let data: Vec<MessageData> = (0..100)
+            .map(|i| {
+                let mut msg = message_store::controls::new_example();
+                msg.position = Some(i);
+                msg.stream_name = Some(stream.clone());
+                msg
+            })
+            .collect();
+
+        message_store::tools::bulk_insert(&mut store.client, data.iter().collect()).unwrap();
+
+        b.iter(|| store.get(&stream, None))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/message_store/get.rs
+++ b/src/message_store/get.rs
@@ -12,16 +12,16 @@ type DataResult = Result<Vec<MessageData>, MessageStoreError>;
 type SingleResult = Result<Option<MessageData>, MessageStoreError>;
 
 pub trait Get {
-    fn get(self, stream_name: &str, position: Option<i64>) -> DataResult;
-    fn get_last(self, stream_name: &str) -> SingleResult;
+    fn get(&mut self, stream_name: &str, position: Option<i64>) -> DataResult;
+    fn get_last(&mut self, stream_name: &str) -> SingleResult;
 }
 
 impl Get for MessageStore {
-    fn get(mut self, stream_name: &str, position: Option<i64>) -> DataResult {
+    fn get(&mut self, stream_name: &str, position: Option<i64>) -> DataResult {
         get(&mut self.client, &mut self.settings, stream_name, position)
     }
 
-    fn get_last(mut self, stream_name: &str) -> SingleResult {
+    fn get_last(&mut self, stream_name: &str) -> SingleResult {
         get_last(&mut self.client, stream_name)
     }
 }


### PR DESCRIPTION
These are so naive they have little value on their own, but it is a step in the right direction.

Things that need to happen between samples:

 - Truncating the data
 - VACUUM / ANALYSE
 - DISCARD ALL

Need to also set up some basic profiling.

For running, need to set up some scripts to spin up consistent instances on EC2, run the benchmarks, upload results, spin down.

All of this is captured in #29

closes #18 